### PR TITLE
Fix compiler error for "make mpi"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,7 +351,7 @@ int wrapped_main(int argv, char **argc) {
 #ifdef MPI_VERSION
   if (__MPI_NUM_TASKS__ == 1) {
     debug_string(EMIT_LEVEL_WARNING,
-                 "Running MPI version with only 1 process, "
+                 "Running MPI version with only 1 process, ");
   }
 #endif
 


### PR DESCRIPTION
This PR fixes a syntax error that is exposed when building root_digger (https://github.com/computations/root_digger/commit/906869952c01291beec4cb7b99077f741aaddd0f) with MPI enabled (using g++ 10.3 and OpenMPI 4.0.5):
```
$ make mpi
...
/src/src/main.cpp:627: error: unterminated argument list invoking macro "debug_string"
  627 | }
      |     
/src/src/main.cpp: In function 'int wrapped_main(int, char**)':
/src/src/main.cpp:353:5: error: 'debug_string' was not declared in this scope 
  353 |     debug_string(EMIT_LEVEL_WARNING,
      |     ^~~~~~~~~~~~
/src/src/main.cpp:353:5: error: expected '}' at end of input 
/src/src/main.cpp:352:31: note: to match this '{'
  352 |   if (__MPI_NUM_TASKS__ == 1) {
      |                               ^     
/src/src/main.cpp:353:5: error: expected '}' at end of input 
  353 |     debug_string(EMIT_LEVEL_WARNING,
      |     ^~~~~~~~~~~~
```